### PR TITLE
dockerized example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:alpine
+
+RUN apk update && apk add curl git && rm -rf /var/cache/apk/*
+
+ADD . /code
+
+RUN go get golang.org/x/net/websocket
+
+EXPOSE 9191
+
+CMD ["go", "run", "/code/server.go"]

--- a/Dockerfile_php
+++ b/Dockerfile_php
@@ -1,0 +1,9 @@
+FROM php
+
+ADD . /code
+
+EXPOSE 80
+
+WORKDIR /code
+
+CMD php -S 0.0.0.0:80 -t /code

--- a/README.md
+++ b/README.md
@@ -3,3 +3,45 @@
 ## Requirements
 
 go get golang.org/x/net/websocket
+
+## Endpoints
+    
+* **:9090**: php webserver, public
+* **:9191**: websocket, public
+* **:9292**: udp server, private only reachable from localhost
+
+## Dockerized Example
+
+### Setup
+This builds two docker images.
+
+* websocket: Contains go and the `server.go` script which is executed at container start. 
+* websocket-php: A PHP 7 docker image, the container will run the built-in webserver
+
+
+    ./bin/build
+    
+### Usage
+
+Start environment:
+
+    ./bin/start
+    
+Call the demo page:
+
+    http://<your development hostname>:9090/index.php
+    
+This opens a websocket and listens to it.
+    
+Send messages through the web socket:
+
+    ./bin/send-messages
+    
+The latest script starts an endless loop! You have to stop the command by hand though!
+
+For the lazy dev there is a shortcut for all those commands:
+
+    ./bin/start-dev
+    
+This builds the Docker Images, starts the environment and sends messages in endless loop!
+

--- a/bin/build
+++ b/bin/build
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+./bin/php-build
+./bin/websocket-build

--- a/bin/php-build
+++ b/bin/php-build
@@ -1,0 +1,6 @@
+#!/bin/bash
+#
+# build the php docker image
+#
+
+docker build --file="Dockerfile_php" -t websocket-php .

--- a/bin/php-enter
+++ b/bin/php-enter
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# enter php container to send some messages for example
+#
+
+cmd=$1
+
+if [ -z "$cmd" ]; then
+    cmd=bash
+fi
+
+docker exec -ti websocket-php $cmd

--- a/bin/send-messages
+++ b/bin/send-messages
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./bin/php-enter "php lorem_ipsum.php 2"

--- a/bin/start
+++ b/bin/start
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+docker rm -f websocket 2> /dev/null
+docker rm -f websocket-php 2> /dev/null
+
+docker run \
+    -d \
+    -p 9191:9191 \
+    --name=websocket \
+    websocket
+
+docker run \
+    -d \
+    -p 9090:80 \
+    --name=websocket-php \
+    --link websocket:udp \
+    -v $(pwd):/code \
+    websocket-php
+

--- a/bin/start-dev
+++ b/bin/start-dev
@@ -1,0 +1,17 @@
+#!/bin/bash
+SKIP_BUILD=0
+
+while getopts ":s" opt; do
+  case $opt in
+    s)
+      SKIP_BUILD=1
+      ;;
+  esac
+done
+
+if [ "$SKIP_BUILD" = "0" ]; then
+    ./bin/build
+fi
+
+./bin/start
+./bin/send-messages

--- a/bin/websocket-build
+++ b/bin/websocket-build
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# build the go docker image where the websocket server is running in
+#
+
+docker build -t websocket .
+

--- a/bin/websocket-logs
+++ b/bin/websocket-logs
@@ -1,0 +1,5 @@
+#!/bin/bash
+#
+# display the logs of the websocket's container
+#
+docker logs -f websocket

--- a/index.php
+++ b/index.php
@@ -1,3 +1,7 @@
+<?php
+$serverParts = explode(':', $_SERVER['HTTP_HOST'], 2);
+$serverName = $serverParts[0];
+?>
 <html>
     <head>
         <title>Websockets</title>
@@ -11,7 +15,7 @@
         <h1 id="message"></h1>
 
         <script type="text/javascript" language="javascript">
-            var ws = new WebSocket("ws://localhost:9191/ws")
+            var ws = new WebSocket("ws://<?php echo $serverName; ?>:9191/ws")
             ws.onmessage = function (message) {
                 var event = JSON.parse(message.data)
 

--- a/lorem_ipsum.php
+++ b/lorem_ipsum.php
@@ -7,7 +7,7 @@ $colors = ["green", "red", "blue", "pink", "yellow", "orange", "black", "cyan"];
 $count = 0;
 
 while (true) {
-    $fp = @stream_socket_client("udp://127.0.0.1:8081", $errno, $errstr, 1);
+    $fp = @stream_socket_client("udp://udp:9292", $errno, $errstr, 1);
     for ($userId = 1; $userId <= $counterUsers; $userId++) {
         $message = $words[$count % count($words)];
         $color = $colors[$count % count($colors)];

--- a/send_message.php
+++ b/send_message.php
@@ -1,6 +1,6 @@
 <?php
 
-$fp = @stream_socket_client("udp://127.0.0.1:8081", $errno, $errstr, 1);
+$fp = @stream_socket_client("udp://udp:9292", $errno, $errstr, 1);
 fwrite($fp, json_encode([
     'UserId' => (int)$argv[1],
     'Name' => 'Message',

--- a/server.go
+++ b/server.go
@@ -10,8 +10,8 @@ import (
 )
 
 var maxId = 0
-var udpAddr string = "127.0.0.1:8081"
-var httpAddr string = ":8080"
+var udpAddr string = ":9292"
+var httpAddr string = ":9191"
 var clients            map[int]*Client
 var clientAdded        chan *Client
 var clientDisconnected chan *Client


### PR DESCRIPTION
I thought it would be helpful to dockerize your example. As I am currently working with CoreOS only everything I try needs to run in container.
With this dockerized example every developer could easily start your example without the need to setup some server on his own. I think this changed setup will motivate other developers to try out this example more often.
Due to this refactoring I had to change some things, which breaks your workflow:
- index.php should be used instead of index.html as the server host is no more static
- the php webserver is reachable via port 9090. In my case port 8080 is already reserved from the default Docker and Kubernetes setup.
- websocket is running on port 9191
- udp server is running on port 9292 and the udp server doesn't listen to localhost anymore. With the dockerized approach this will be no security problem at all because the port is not reachable from outside.

Other stuff is explained in the README.

I am ware of the fact that this breaks a lot for you and that you have to adopt your slides and setup, but I think for other developers would this PR quite helpful.

What do you think?
